### PR TITLE
Use lstsquares for stationary distribution.

### DIFF
--- a/src/hierarchy/stationary.py
+++ b/src/hierarchy/stationary.py
@@ -8,7 +8,8 @@ def get_stationary_distribution(capacities, r, lmbda, mu):
         capacities=capacities, r=r, lmbda=lmbda, mu=mu
     )
 
-    vals, vects = np.linalg.eig(matrix.transpose())
-    zero_eigenvector = vects.transpose()[np.argmin(np.abs(vals))]
-    total = sum(zero_eigenvector)
-    return zero_eigenvector / total
+    dimension = matrix.shape[0]
+    M = np.vstack((matrix.transpose(), np.ones(dimension)))
+    b = np.vstack((np.zeros((dimension, 1)), [1]))
+
+    return np.linalg.lstsq(M, b)[0].transpose()[0]

--- a/tests/test_stationary.py
+++ b/tests/test_stationary.py
@@ -19,6 +19,7 @@ def test_stationary():
     assert np.allclose(pi @ matrix, 0)
     assert len(pi) == matrix.shape[0]
     assert np.min(pi) >= 0
+    assert np.sum(pi) == 1
 
 
 def test_stationary_example_two():
@@ -36,4 +37,5 @@ def test_stationary_example_two():
 
     assert np.allclose(pi @ matrix, 0)
     assert len(pi) == matrix.shape[0]
-    assert np.min(pi) >= 0
+    assert np.min(pi) >= -10 ** -7
+    assert np.isclose(np.sum(pi), 1)


### PR DESCRIPTION
When using a direct solution of the linear system it is difficult to
know which row to remove.

Closes #17